### PR TITLE
Added feature-test folder code

### DIFF
--- a/eval/EVAL_README.md
+++ b/eval/EVAL_README.md
@@ -1,10 +1,5 @@
 # Evaluation
 
-We provide scripts to evaluate model responses with GPT-4. We also provide a script to generate new responses using the OpenAI API. These scripts are based on the evaluation scripts of the [FastChat repo](https://github.com/lm-sys/FastChat/tree/main/fastchat/eval).
-
-## Benchmark Queries
-In our paper we use both Vicuna and Open Assistant data. The exact queries for both benchmarks are found at `prompts/vicuna_questions.jsonl` and `prompts/oa_questions.jsonl`. Note that the Vicuna questions are the same set of 80 prompts found in the FastChat repo. For the OpenAssistant benchmark, we select all the user queries in the validation dataset. We also include the previous turns in the dialog for context when applicable.
-
 ## Sample Generations and Model Ratings
 The `generation` folder has outputs from the models studied in our paper. This includes generations for all model sizes (from 7B to 65B) and instruction following datasets.
 

--- a/feature-test/eval_metrics.py
+++ b/feature-test/eval_metrics.py
@@ -1,0 +1,9 @@
+from transformers import TrainerCallback
+
+class GenerationCallback(TrainerCallback):
+    def on_epoch_end(self, args, state, control, **kwargs):
+        sample = "Your prompt here"
+        gen = model.generate(**tokenizer(sample, return_tensors="pt"))
+        text = tokenizer.decode(gen[0], skip_special_tokens=True)
+        # compute ROUGE/perplexity here, then log to W&B or stdout
+        print(f"\n>>> Generated sample: {text}\n")

--- a/feature-test/trainer.py
+++ b/feature-test/trainer.py
@@ -1,0 +1,10 @@
+from transformers import EarlyStoppingCallback
+
+trainer = Trainer(
+  model=model,
+  args=training_args,
+  train_dataset=train_dataset,
+  eval_dataset=eval_dataset,
+  data_collator=data_collator,
+  callbacks=[EarlyStoppingCallback(early_stopping_patience=2)]
+)

--- a/feature-test/wb_parameter.py
+++ b/feature-test/wb_parameter.py
@@ -1,0 +1,12 @@
+import wandb
+from transformers.integrations import WandbCallback
+
+wandb.init(project="qlora-finetune")
+trainer = Trainer(
+  model=model,
+  args=training_args,
+  train_dataset=train_dataset,
+  eval_dataset=eval_dataset,
+  data_collator=data_collator,
+  callbacks=[WandbCallback()]
+)


### PR DESCRIPTION
In your Trainer instantiation, add the built-in callback so you don’t waste epochs once validation loss plateaus: This will stop training if the eval loss doesn’t improve for 2 eval rounds—and still save your best checkpoint. Add a simple pytest that loads a tiny model, runs one train step, and checks loss decreases. This gives you confidence before pushing to main.